### PR TITLE
Remove nodejs exclusivearch block.

### DIFF
--- a/iml-realtime.spec.template
+++ b/iml-realtime.spec.template
@@ -12,10 +12,10 @@ Source0:  %{name}-%{version}.tgz
 %{?systemd_requires}
 BuildRequires: systemd
 
+Requires: nodejs
 BuildRequires: nodejs-packaging
 BuildRequires: npm
 
-ExclusiveArch: %{nodejs_arches}
 
 %description
 This modules provides realtime data to the GUI.


### PR DESCRIPTION
It appears ExlusiveArch is bringing in a requirement on nodejs 8.

Remove the ExclusiveArch block.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>