### PR TITLE
Try to filter out nodejs version > 8

### DIFF
--- a/iml-realtime.spec.template
+++ b/iml-realtime.spec.template
@@ -1,3 +1,5 @@
+%{?nodejs_default_filter}
+
 %define base_name realtime
 
 Name:     iml-%{base_name}


### PR DESCRIPTION
Add %{?nodejs_default_filter} to try and filter out the autoprovides
occurring in the realtime build.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>