### PR TITLE
Exclude requires

### DIFF
--- a/iml-realtime.spec.template
+++ b/iml-realtime.spec.template
@@ -1,4 +1,6 @@
 %{?nodejs_default_filter}
+%global __requires_exclude_from ^%{nodejs_sitelib}/.*$
+
 
 %define base_name realtime
 


### PR DESCRIPTION
Exclude the requires that are being auto-generated.

These appear to come from node_modules.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>