### PR TITLE
Fix session issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,6 @@ const io = createIo();
 const errorHandler = msg => error => {
   console.error(msg, error);
 
-  process.exitCode = 1;
-
   io.close();
   pool.end(() => {
     pool._clients.forEach(c => {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ const errorHandler = msg => error => {
       c.connection.stream.unref();
     });
   });
+
+  process.exit(process.exitCode);
 };
 
 process.on("unhandledRejection", errorHandler("unhandled promise rejection"));

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const errorHandler = msg => error => {
     });
   });
 
-  process.exit(process.exitCode);
+  process.exit(1);
 };
 
 process.on("unhandledRejection", errorHandler("unhandled promise rejection"));

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -292,10 +292,6 @@ describe("realtime index test", () => {
       expect(console.error).toHaveBeenCalledWith("unhandled promise rejection", e);
     });
 
-    it("should exit with a return code of 1", () => {
-      expect(process.exitCode).toBe(1);
-    });
-
     it("should exit the process", () => {
       expect(process.exit).toHaveBeenCalledTimes(1);
       expect(process.exit).toHaveBeenCalledWith(1);


### PR DESCRIPTION
Realtime handles uncaught exceptions but does not then exit the process.
This causes 502's on the nginx side. Make sure the process exits after
handling the uncaught exception.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>